### PR TITLE
Add a different owner than the eoa as contract owner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,8 @@
-DEPLOYER_PRIVATE_KEY=
+# Private key of the EOA to be upgraded to a smart contract wallet
 EOA_PRIVATE_KEY=
+
+# Private key of the account that will deploy contracts and perform the upgrade
+DEPLOYER_PRIVATE_KEY=
+
+# Private key of the new owner to be added to the smart wallet
+NEW_OWNER_PRIVATE_KEY=

--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ This repository contains scripts that can be used to perform an EIP-7702 upgrade
 
 ### Prerequisites
 - Foundry installed
-- If you're using the Odyssey testnet, you'll need two private keys funded with some Odyssey ETH (see `.env.example`):
+- If you're using the Odyssey testnet, you'll need three private keys funded with some Odyssey ETH (see `.env.example`):
     - `EOA_PRIVATE_KEY`: The private key of the EOA to be upgraded
     - `DEPLOYER_PRIVATE_KEY`: The private key of the EOA that will perform the upgrade
+    - `NEW_OWNER_PRIVATE_KEY`: The private key of another EOA that will be added as an owner
 
 Odyssey Chain Info: https://hub.conduit.xyz/odyssey
 

--- a/script/Initialize.s.sol
+++ b/script/Initialize.s.sol
@@ -28,8 +28,14 @@ import {ECDSA} from "openzeppelin-contracts/contracts/utils/cryptography/ECDSA.s
  */
 contract Initialize is Script {
     // Anvil's default funded accounts (for local testing)
-    address constant _ANVIL_ALICE = 0x70997970C51812dc3A010C7d01b50e0d17dc79C8;
-    uint256 constant _ANVIL_ALICE_PK = 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d;
+    address constant _ANVIL_EOA = 0x70997970C51812dc3A010C7d01b50e0d17dc79C8;
+    uint256 constant _ANVIL_EOA_PK = 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d;
+    // Using another Anvil account as the new owner
+    address constant _ANVIL_NEW_OWNER = 0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC;
+    uint256 constant _ANVIL_NEW_OWNER_PK = 0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a;
+    // Using the deployer account as recipient for test transactions
+    address constant _ANVIL_DEPLOYER = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
+    uint256 constant _ANVIL_DEPLOYER_PK = 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80;
 
     // Chain IDs
     uint256 constant _ANVIL_CHAIN_ID = 31337;
@@ -43,32 +49,44 @@ contract Initialize is Script {
         // Determine which environment we're in
         address eoa;
         uint256 eoaPk;
+        address newOwner;
+        uint256 newOwnerPk;
+        address deployer;
         address proxyAddr;
 
         if (block.chainid == _ANVIL_CHAIN_ID) {
             console.log("Using Anvil's pre-funded accounts");
-            eoa = _ANVIL_ALICE;
-            eoaPk = _ANVIL_ALICE_PK;
+            eoa = _ANVIL_EOA;
+            eoaPk = _ANVIL_EOA_PK;
+            newOwner = _ANVIL_NEW_OWNER;
+            newOwnerPk = _ANVIL_NEW_OWNER_PK;
+            deployer = _ANVIL_DEPLOYER;
             proxyAddr = _PROXY_ADDRESS_ANVIL;
         } else if (block.chainid == _ODYSSEY_CHAIN_ID) {
             console.log("Using Odyssey testnet with environment variables");
             eoaPk = vm.envUint("EOA_PRIVATE_KEY");
             eoa = vm.addr(eoaPk);
+            newOwnerPk = vm.envUint("NEW_OWNER_PRIVATE_KEY");
+            newOwner = vm.addr(newOwnerPk);
+            uint256 deployerPk = vm.envUint("DEPLOYER_PRIVATE_KEY");
+            deployer = vm.addr(deployerPk);
             proxyAddr = _PROXY_ADDRESS_ODYSSEY;
         } else {
             revert("Unsupported chain ID");
         }
 
         console.log("EOA address:", eoa);
+        console.log("New owner address:", newOwner);
+        console.log("Deployer address (recipient):", deployer);
         console.log("Using proxy template at:", proxyAddr);
 
         // First verify the EOA has code
         require(address(eoa).code.length > 0, "EOA not upgraded yet! Run UpgradeEOA.s.sol first");
         console.log("[OK] Verified EOA has been upgraded");
 
-        // Create and sign the initialize data
+        // Create and sign the initialize data with just the new owner
         bytes[] memory owners = new bytes[](1);
-        owners[0] = abi.encode(eoa);
+        owners[0] = abi.encode(newOwner);
         bytes memory initArgs = abi.encode(owners);
         bytes32 initHash = keccak256(abi.encode(proxyAddr, initArgs));
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(eoaPk, initHash);
@@ -93,13 +111,36 @@ contract Initialize is Script {
 
         vm.stopBroadcast();
         
-        // Verify ownership
+        // Verify ownership for the new owner
         CoinbaseSmartWallet smartWallet = CoinbaseSmartWallet(payable(eoa));
-        bool isOwner = smartWallet.isOwnerAddress(eoa);
-        require(isOwner, "EOA is not an owner of the smart wallet!");
-        console.log("[OK] Verified EOA is an owner of the smart wallet");
+        bool isNewOwner = smartWallet.isOwnerAddress(newOwner);
+        require(isNewOwner, "New owner is not an owner of the smart wallet!");
+        console.log("[OK] Verified new owner is the owner of the smart wallet");
 
-        // Verifying that the EOA can call `execute` on the smart wallet isn't an interesting test because
-        // the EOA passes the `_isOwnerOrEntrypoint` check simply by way of being the address of itself, the smart wallet.
+        // Test that the new owner can execute a transaction
+        // We'll try to send some ETH to the deployer account
+        uint256 amount = 0.001 ether;
+        uint256 deployerBalanceBefore = deployer.balance;
+        console.log("Deployer balance before:", deployerBalanceBefore);
+
+        vm.startBroadcast(newOwnerPk);
+        
+        // Empty calldata for a simple ETH transfer
+        bytes memory callData = "";
+        smartWallet.execute(
+            payable(deployer),  // target: sending to the deployer
+            amount,             // value: amount of ETH to send
+            callData           // data: empty for simple ETH transfer
+        );
+
+        uint256 deployerBalanceAfter = deployer.balance;
+        console.log("Deployer balance after:", deployerBalanceAfter);
+        require(
+            deployerBalanceAfter == deployerBalanceBefore + amount,
+            "ETH transfer failed - deployer balance did not increase by the expected amount"
+        );
+        console.log("[OK] New owner successfully called execute");
+
+        vm.stopBroadcast();
     }
 } 

--- a/script/UpgradeEOA.s.sol
+++ b/script/UpgradeEOA.s.sol
@@ -54,8 +54,8 @@ contract UpgradeEOA is Script {
     using Strings for uint256;
 
     // Anvil's default funded accounts (for local testing)
-    address constant _ANVIL_ALICE = 0x70997970C51812dc3A010C7d01b50e0d17dc79C8;
-    uint256 constant _ANVIL_ALICE_PK = 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d;
+    address constant _ANVIL_EOA = 0x70997970C51812dc3A010C7d01b50e0d17dc79C8;
+    uint256 constant _ANVIL_EOA_PK = 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d;
     uint256 constant _ANVIL_DEPLOYER_PK = 0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6;
 
     // Chain IDs
@@ -72,8 +72,8 @@ contract UpgradeEOA is Script {
         if (block.chainid == _ANVIL_CHAIN_ID) {
             console.log("Using Anvil's pre-funded accounts");
             deployerPk = _ANVIL_DEPLOYER_PK;
-            eoaPk = _ANVIL_ALICE_PK;
-            eoa = _ANVIL_ALICE;
+            eoaPk = _ANVIL_EOA_PK;
+            eoa = _ANVIL_EOA;
         } else if (block.chainid == _ODYSSEY_CHAIN_ID) {
             console.log("Using Odyssey testnet with environment variables");
             deployerPk = vm.envUint("DEPLOYER_PRIVATE_KEY");


### PR DESCRIPTION
Tests to make sure an owner that is not the EOA address itself (which has elevated privilege in the smart contract) can also successfully call `execute`